### PR TITLE
Define CURLOPT_POSTFIELDS with empty array if no post data

### DIFF
--- a/library/Litmus/RESTful/Client.php
+++ b/library/Litmus/RESTful/Client.php
@@ -201,9 +201,12 @@ class Litmus_RESTful_Client {
         );
         curl_setopt($this->_curl_handle, CURLOPT_HTTPHEADER, $headers);
         //curl_setopt($this->_curl_handle, CURLOPT_VERBOSE, true);
-        if ($request !== null) {
-            curl_setopt($this->_curl_handle, CURLOPT_POSTFIELDS, $request);
+
+        if ($request === null) {
+            $request = [];
         }
+        curl_setopt($this->_curl_handle, CURLOPT_POSTFIELDS, $request);
+
         $this->_performCurlSession();
         return $this->_curl_result;
     }


### PR DESCRIPTION
To avoid 400 code response from Litmus API, always define CURLOPT_POSTFIELDS curl option for post requests. If the $request parameter is null set it to empty array. 