### PR TITLE
Made all require statements absolute paths

### DIFF
--- a/library/Litmus.php
+++ b/library/Litmus.php
@@ -10,8 +10,8 @@
 /**
  *
  */
-require_once 'Litmus/RESTful/Client.php';
-require_once 'Litmus/Test.php';
+require_once __DIR__ . '/Litmus/RESTful/Client.php';
+require_once __DIR__ . '/Litmus/Test.php';
 
 /**
  *

--- a/library/Litmus/RESTful/Client.php
+++ b/library/Litmus/RESTful/Client.php
@@ -11,7 +11,7 @@
 /**
  *
  */
-require_once 'Litmus/RESTful/Server.php';
+require_once __DIR__ . '/Server.php';
 
 /**
  *

--- a/library/Litmus/Result.php
+++ b/library/Litmus/Result.php
@@ -10,9 +10,9 @@
 /**
  *
  */
-require_once('Litmus/Result/Testing/Application.php');
-require_once('Litmus/Result/Image.php');
-require_once('Litmus/Result/ResultHeader.php');
+require_once __DIR__ . '/Result/Testing/Application.php';
+require_once __DIR__ . '/Result/Image.php';
+require_once __DIR__ . '/Result/ResultHeader.php';
 
 /**
  *

--- a/library/Litmus/Result/ResultHeader.php
+++ b/library/Litmus/Result/ResultHeader.php
@@ -7,7 +7,7 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD License
  */
 
-require_once('Litmus/Result/ResultHeader/Spam.php');
+require_once __DIR__ . '/ResultHeader/Spam.php';
 
 /**
  *

--- a/library/Litmus/Test.php
+++ b/library/Litmus/Test.php
@@ -11,9 +11,8 @@
 /**
  *
  */
-require_once 'Litmus/Test.php';
-require_once 'Litmus/Version.php';
-require_once 'Litmus/Test/Client.php';
+require_once __DIR__ . '/Version.php';
+require_once __DIR__ . '/Test/Client.php';
 
 /**
  *

--- a/library/Litmus/Version.php
+++ b/library/Litmus/Version.php
@@ -10,7 +10,7 @@
 /**
  *
  */
-require_once 'Litmus/Result.php';
+require_once __DIR__ . '/Result.php';
 
 /**
  *

--- a/tests/Litmus/TestSetMethodTest.php
+++ b/tests/Litmus/TestSetMethodTest.php
@@ -12,7 +12,7 @@
 /**
  * Include test helper
  */
-require_once dirname(__FILE__) . '/../TestHelper.php';
+require_once __DIR__ . '/../TestHelper.php';
 
 /**
  * Unit test class for Litmus Test Set Methods 

--- a/tests/Litmus/TestSetVersionMethodsTest.php
+++ b/tests/Litmus/TestSetVersionMethodsTest.php
@@ -11,7 +11,7 @@
 /**
  * Include test helper
  */
-require_once dirname(__FILE__) . '/../TestHelper.php';
+require_once __DIR__ . '/../TestHelper.php';
 
 /**
  * Unit test class for Litmus Test Set Version Methods

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -21,7 +21,7 @@ set_include_path(
     . BASE_PATH . '/tests' . PATH_SEPARATOR
     . get_include_path());
 
-require_once 'Litmus.php';
+require_once __DIR__ . '/../library/Litmus.php';
 Litmus::setAPICredentials(
     'geelweb', 'gluchet', 'xxxxxx',
     array(


### PR DESCRIPTION
Updates all `require_once` statements to use absolute paths, based off of the `__DIR__` magic constant (≥PHP5.3). Resolves #3.