### PR TITLE
Fix unresolvable class ref

### DIFF
--- a/src/RESTful/Client.php
+++ b/src/RESTful/Client.php
@@ -103,7 +103,7 @@ class Client
         curl_close($this->_curl_handle);
 
         if (preg_match('/^[3|4|5][0-9]{2}$/', $this->_curl_info['http_code'])) {
-            throw new Exception(sprintf(
+            throw new \Exception(sprintf(
                 'An error occurs calling %s : %s (http_code %s) : %s',
                 $this->_curl_info['url'],
                 $this->_curl_error,

--- a/src/Test.php
+++ b/src/Test.php
@@ -20,6 +20,7 @@ class Test
      */
     public static function getTests($test_id=null)
     {
+        /** @var Client $rc */
         $rc = Client::singleton();
         if ($test_id === null) {
             $res = $rc->get('tests.xml');


### PR DESCRIPTION
This commit fixes the following error:

    [Symfony\Component\Debug\Exception\FatalThrowableError]
    Class 'Geelweb\Litmus\RESTful\Exception' not found

With this solution, exceptions are thrown properly:
                                                                                                                 
    [Exception]
    An error occurs calling https://foobar.litmus.com/tests.xml :  (http_code 401) : Couldn't authenticate you
