### PR TITLE
Allow php56 requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 5.6
   - 7.0
   - 7.1
 install:

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "psr-4": {"Geelweb\\Litmus\\Tests\\": "tests/"}
     },
     "require": {
-        "php": "^7.0"
+        "php": "~5.6|~7.0"
     }
 }


### PR DESCRIPTION
Hi @geelweb, I had to change this in order to be able to use the package for a php56 based project.

I didn't see a problem or a reason for limiting usage to php70.